### PR TITLE
Implement player movement and navigation CU-86bxaj07m

### DIFF
--- a/projects/hacking-minigame/src/levels/sandbox.tscn
+++ b/projects/hacking-minigame/src/levels/sandbox.tscn
@@ -70,9 +70,10 @@ position = Vector2(600, 300)
 [node name="NetworkNode5" parent="Network/NetworkNodes" instance=ExtResource("3_phs73")]
 position = Vector2(600, 0)
 
-[node name="Player" parent="." node_paths=PackedStringArray("networkNode") instance=ExtResource("4_4pimd")]
+[node name="Player" parent="." node_paths=PackedStringArray("Network", "NetworkNode") instance=ExtResource("4_4pimd")]
 position = Vector2(56, 79)
-networkNode = NodePath("../Network/NetworkNodes/NetworkNode0")
+Network = NodePath("../Network")
+NetworkNode = NodePath("../Network/NetworkNodes/NetworkNode0")
 
 [node name="PlayerMovementController" type="Node2D" parent="." node_paths=PackedStringArray("Network", "Player")]
 script = ExtResource("5_hghsw")

--- a/projects/hacking-minigame/src/levels/sandbox.tscn
+++ b/projects/hacking-minigame/src/levels/sandbox.tscn
@@ -70,10 +70,9 @@ position = Vector2(600, 300)
 [node name="NetworkNode5" parent="Network/NetworkNodes" instance=ExtResource("3_phs73")]
 position = Vector2(600, 0)
 
-[node name="Player" parent="." node_paths=PackedStringArray("networkNode", "nodePath") instance=ExtResource("4_4pimd")]
+[node name="Player" parent="." node_paths=PackedStringArray("networkNode") instance=ExtResource("4_4pimd")]
 position = Vector2(56, 79)
 networkNode = NodePath("../Network/NetworkNodes/NetworkNode0")
-nodePath = [NodePath("../Network/NetworkNodes/NetworkNode0")]
 
 [node name="PlayerMovementController" type="Node2D" parent="." node_paths=PackedStringArray("Network", "Player")]
 script = ExtResource("5_hghsw")

--- a/projects/hacking-minigame/src/levels/sandbox.tscn
+++ b/projects/hacking-minigame/src/levels/sandbox.tscn
@@ -1,8 +1,9 @@
-[gd_scene load_steps=4 format=3 uid="uid://d3p67j68lg26b"]
+[gd_scene load_steps=5 format=3 uid="uid://d3p67j68lg26b"]
 
 [ext_resource type="Script" path="res://src/network/Network.cs" id="1_r1xda"]
 [ext_resource type="PackedScene" uid="uid://dsx77i0fiws4x" path="res://src/network/edge.tscn" id="2_ifm2w"]
 [ext_resource type="PackedScene" uid="uid://cbnnj6rc7ldlx" path="res://src/network/network_node.tscn" id="3_phs73"]
+[ext_resource type="PackedScene" uid="uid://drkhn2puxovdv" path="res://src/player/player.tscn" id="4_4pimd"]
 
 [node name="Sandbox" type="Node2D"]
 
@@ -56,3 +57,8 @@ position = Vector2(600, 300)
 
 [node name="NetworkNode5" parent="Network/NetworkNodes" instance=ExtResource("3_phs73")]
 position = Vector2(600, 0)
+
+[node name="Player" parent="." node_paths=PackedStringArray("networkNode", "nodePath") instance=ExtResource("4_4pimd")]
+position = Vector2(199, 149)
+networkNode = NodePath("../Network/NetworkNodes/NetworkNode0")
+nodePath = [NodePath("../Network/NetworkNodes/NetworkNode0"), NodePath("../Network/NetworkNodes/NetworkNode1"), NodePath("../Network/NetworkNodes/NetworkNode2"), NodePath("../Network/NetworkNodes/NetworkNode5")]

--- a/projects/hacking-minigame/src/levels/sandbox.tscn
+++ b/projects/hacking-minigame/src/levels/sandbox.tscn
@@ -1,17 +1,29 @@
-[gd_scene load_steps=5 format=3 uid="uid://d3p67j68lg26b"]
+[gd_scene load_steps=7 format=3 uid="uid://d3p67j68lg26b"]
 
 [ext_resource type="Script" path="res://src/network/Network.cs" id="1_r1xda"]
 [ext_resource type="PackedScene" uid="uid://dsx77i0fiws4x" path="res://src/network/edge.tscn" id="2_ifm2w"]
+[ext_resource type="Script" path="res://src/network/NetworkNodePathVisualizer.cs" id="2_kbp3g"]
 [ext_resource type="PackedScene" uid="uid://cbnnj6rc7ldlx" path="res://src/network/network_node.tscn" id="3_phs73"]
 [ext_resource type="PackedScene" uid="uid://drkhn2puxovdv" path="res://src/player/player.tscn" id="4_4pimd"]
+[ext_resource type="Script" path="res://src/player/PlayerMovementController.cs" id="5_hghsw"]
 
 [node name="Sandbox" type="Node2D"]
 
-[node name="Network" type="Node2D" parent="." node_paths=PackedStringArray("Nodes", "Edges")]
+[node name="Network" type="Node2D" parent="."]
 position = Vector2(300, 150)
 script = ExtResource("1_r1xda")
-Nodes = []
-Edges = []
+
+[node name="PlayerNavigationPreviewVisualizer" type="Node2D" parent="Network"]
+script = ExtResource("2_kbp3g")
+PathNodeColor = Color(0, 1, 0, 0)
+TrackedStartNodeColor = Color(0, 1, 0, 0)
+
+[node name="PlayerNavigationPathVisualizer" type="Node2D" parent="Network"]
+script = ExtResource("2_kbp3g")
+PathNodeColor = Color(0.858824, 0.278431, 0.262745, 0)
+PathEdgeColor = Color(0.72549, 0.392157, 0.160784, 1)
+TrackedStartNodeColor = Color(0.858824, 0.278431, 0.262745, 0)
+TrackedStartNodeEdgeColor = Color(0.72549, 0.392157, 0.160784, 1)
 
 [node name="Edges" type="Node2D" parent="Network"]
 
@@ -59,6 +71,11 @@ position = Vector2(600, 300)
 position = Vector2(600, 0)
 
 [node name="Player" parent="." node_paths=PackedStringArray("networkNode", "nodePath") instance=ExtResource("4_4pimd")]
-position = Vector2(199, 149)
+position = Vector2(56, 79)
 networkNode = NodePath("../Network/NetworkNodes/NetworkNode0")
-nodePath = [NodePath("../Network/NetworkNodes/NetworkNode0"), NodePath("../Network/NetworkNodes/NetworkNode1"), NodePath("../Network/NetworkNodes/NetworkNode2"), NodePath("../Network/NetworkNodes/NetworkNode5")]
+nodePath = [NodePath("../Network/NetworkNodes/NetworkNode0")]
+
+[node name="PlayerMovementController" type="Node2D" parent="." node_paths=PackedStringArray("Network", "Player")]
+script = ExtResource("5_hghsw")
+Network = NodePath("../Network")
+Player = NodePath("../Player")

--- a/projects/hacking-minigame/src/network/Edge.cs
+++ b/projects/hacking-minigame/src/network/Edge.cs
@@ -13,9 +13,16 @@ public partial class Edge : Node2D
         get => _from;
         set
         {
+            if (_from is not null)
+            {
+                _from.NetworkNodePositionChanged -= OnNetworkNodePositionChanged;
+            }
             _from = value;
-            _from.NetworkNodePositionChanged += OnNetworkNodePositionChanged;
-            Redraw();
+            if (_from is not null)
+            {
+                _from.NetworkNodePositionChanged += OnNetworkNodePositionChanged;
+                RedrawEdge();
+            }
         }
     }
 
@@ -25,21 +32,21 @@ public partial class Edge : Node2D
         get => _to;
         set
         {
+            if (_to is not null)
+            {
+                _to.NetworkNodePositionChanged -= OnNetworkNodePositionChanged;
+            }
             _to = value;
-            _to.NetworkNodePositionChanged += OnNetworkNodePositionChanged;
-            Redraw();
+            if (_to is not null)
+            {
+                _to.NetworkNodePositionChanged += OnNetworkNodePositionChanged;
+                RedrawEdge();
+            }
         }
     }
 
     private NetworkNode _from;
     private NetworkNode _to;
-
-    public override void _Ready()
-    {
-        SubsctibeToNetworkNodeEvents();
-        PropertyListChanged += Redraw;
-        Redraw();
-    }
 
     public override void _Draw()
     {
@@ -49,30 +56,9 @@ public partial class Edge : Node2D
         }
     }
 
-    public override void _Notification(int notification)
-    {
-        if (notification == NotificationDragEnd)
-        {
-            return;
-        }
-    }
-
-    private void SubsctibeToNetworkNodeEvents()
-    {
-        if (From is not null)
-        {
-            From.NetworkNodePositionChanged += OnNetworkNodePositionChanged;
-        }
-
-        if (To is not null)
-        {
-            To.NetworkNodePositionChanged += OnNetworkNodePositionChanged;
-        }
-    }
-
     private void OnNetworkNodePositionChanged(NetworkNode node)
     {
-        Redraw();
+        RedrawEdge();
     }
 
     public void Initialize(Network newNetwork)
@@ -80,8 +66,11 @@ public partial class Edge : Node2D
         network = newNetwork;
     }
 
-    public void Redraw()
+    public void RedrawEdge()
     {
-        QueueRedraw();
+        if (From is not null && To is not null)
+        {
+            QueueRedraw();
+        }
     }
 }

--- a/projects/hacking-minigame/src/network/Network.cs
+++ b/projects/hacking-minigame/src/network/Network.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+using System.Linq;
 using Godot;
 using Godot.Collections;
 using shared;
@@ -6,22 +8,100 @@ namespace network;
 
 public partial class Network : Node2D
 {
-    [Export] public Array<NetworkNode> Nodes = null;
-    [Export] public Array<Edge> Edges = null;
+    public Array<NetworkNode> Nodes = null;
+    public Array<Edge> Edges = null;
+
+    public NetworkNodePathVisualizer PlayerNavigationPathVisualizer;
+    public NetworkNodePathVisualizer PlayerNavigationPreviewVisualizer;
+
+    private AStar2D navigation;
+
+    [Signal] public delegate void NetworkNodeClickedEventHandler(NetworkNode node, Network network);
+    [Signal] public delegate void NetworkNodeMouseEnterEventHandler(NetworkNode node, Network network);
+    [Signal] public delegate void NetworkNodeMouseExitEventHandler(NetworkNode node, Network network);
 
     public override void _Ready()
     {
+        PlayerNavigationPathVisualizer = GetNode<NetworkNodePathVisualizer>("PlayerNavigationPathVisualizer");
+
+        PlayerNavigationPreviewVisualizer = GetNode<NetworkNodePathVisualizer>("PlayerNavigationPreviewVisualizer");
+
+        navigation = new();
+
         Nodes = GetNode("NetworkNodes").GetChildren<NetworkNode>();
         Edges = GetNode("Edges").GetChildren<Edge>();
 
         foreach (var node in Nodes)
         {
             node.Initialize(this);
+            node.NetworkNodeClicked += OnNetworkNodeClicked;
+            node.NetworkNodeMouseEnter += OnNetworkNodeMouseEnter;
+            node.NetworkNodeMouseExit += OnNetworkNodeMouseExit;
+
+            navigation.AddPoint((long)node.GetInstanceId(), node.GlobalPosition);
         }
 
         foreach (var edge in Edges)
         {
             edge.Initialize(this);
+            navigation.ConnectPoints((long)edge.From.GetInstanceId(), (long)edge.To.GetInstanceId());
         }
+    }
+
+    public (List<NetworkNode>, List<Edge>) GetNavigationPath(NetworkNode start, NetworkNode end)
+    {
+        var resultNodes = new List<NetworkNode>();
+
+        var pathNodeIds = navigation.GetIdPath((long)start.GetInstanceId(), (long)end.GetInstanceId()).ToList();
+
+        // NOTE: need to preserve order of nodes in here
+        foreach (var pathNodeId in pathNodeIds)
+        {
+            foreach (var node in Nodes)
+            {
+                if ((long)node.GetInstanceId() == pathNodeId)
+                {
+                    resultNodes.Add(node);
+                }
+            }
+        }
+
+        var resultEdges = GetEdgesOfNodePath(resultNodes);
+
+        return (resultNodes, resultEdges);
+    }
+
+    public List<Edge> GetEdgesOfNodePath(IEnumerable<NetworkNode> nodePath)
+    {
+        var resultEdges = new List<Edge>();
+
+        foreach (var node in nodePath)
+        {
+            foreach (var edge in Edges)
+            {
+                if (nodePath.Any(n => n.GetInstanceId() == edge.From.GetInstanceId()) &&
+                nodePath.Any(n => n.GetInstanceId() == edge.To.GetInstanceId()))
+                {
+                    resultEdges.Add(edge);
+                }
+            }
+        }
+
+        return resultEdges;
+    }
+
+    private void OnNetworkNodeClicked(NetworkNode node)
+    {
+        EmitSignal(nameof(NetworkNodeClicked), node, this);
+    }
+
+    private void OnNetworkNodeMouseEnter(NetworkNode node)
+    {
+        EmitSignal(nameof(NetworkNodeMouseEnter), node, this);
+    }
+
+    private void OnNetworkNodeMouseExit(NetworkNode node)
+    {
+        EmitSignal(nameof(NetworkNodeMouseExit), node, this);
     }
 }

--- a/projects/hacking-minigame/src/network/Network.cs
+++ b/projects/hacking-minigame/src/network/Network.cs
@@ -22,7 +22,6 @@ public partial class Network : Node2D
         foreach (var edge in Edges)
         {
             edge.Initialize(this);
-            edge.Redraw();
         }
     }
 }

--- a/projects/hacking-minigame/src/network/NetworkNode.cs
+++ b/projects/hacking-minigame/src/network/NetworkNode.cs
@@ -5,13 +5,16 @@ namespace network;
 [Tool]
 public partial class NetworkNode : Node2D
 {
-    [Export] public Network network;
+    [Export] public Area2D ClickableArea;
+    [Export] public Network Network;
 
     [Signal] public delegate void NetworkNodePositionChangedEventHandler(NetworkNode node);
 
     public override void _Ready()
     {
         SetNotifyLocalTransform(true);
+
+        ClickableArea = GetNode<Area2D>("ClickableArea");
     }
 
     public override void _Notification(int notification)
@@ -25,6 +28,6 @@ public partial class NetworkNode : Node2D
 
     public void Initialize(Network newNetwork)
     {
-        network = newNetwork;
+        Network = newNetwork;
     }
 }

--- a/projects/hacking-minigame/src/network/NetworkNode.cs
+++ b/projects/hacking-minigame/src/network/NetworkNode.cs
@@ -5,16 +5,25 @@ namespace network;
 [Tool]
 public partial class NetworkNode : Node2D
 {
-    [Export] public Area2D ClickableArea;
     [Export] public Network Network;
 
     [Signal] public delegate void NetworkNodePositionChangedEventHandler(NetworkNode node);
+    [Signal] public delegate void NetworkNodeClickedEventHandler(NetworkNode node);
+    [Signal] public delegate void NetworkNodeMouseEnterEventHandler(NetworkNode node);
+    [Signal] public delegate void NetworkNodeMouseExitEventHandler(NetworkNode node);
+
+    private Area2D ClickableArea;
 
     public override void _Ready()
     {
         SetNotifyLocalTransform(true);
 
         ClickableArea = GetNode<Area2D>("ClickableArea");
+
+        ClickableArea.InputPickable = true;
+        ClickableArea.InputEvent += OnNodeClicked;
+        ClickableArea.MouseEntered += OnNodeMouseEnter;
+        ClickableArea.MouseExited += OnNodeMouseExit;
     }
 
     public override void _Notification(int notification)
@@ -29,5 +38,27 @@ public partial class NetworkNode : Node2D
     public void Initialize(Network newNetwork)
     {
         Network = newNetwork;
+    }
+
+    private void OnNodeClicked(Node viewport, InputEvent @event, long shapeIdx)
+    {
+        if (@event is InputEventMouseButton mouseButton)
+        {
+            if (mouseButton.IsPressed() && mouseButton.ButtonIndex == MouseButton.Right)
+            {
+                EmitSignal(nameof(NetworkNodeClicked), this);
+                return;
+            }
+        }
+    }
+
+    private void OnNodeMouseEnter()
+    {
+        EmitSignal(nameof(NetworkNodeMouseEnter), this);
+    }
+
+    private void OnNodeMouseExit()
+    {
+        EmitSignal(nameof(NetworkNodeMouseExit), this);
     }
 }

--- a/projects/hacking-minigame/src/network/NetworkNodePathVisualizer.cs
+++ b/projects/hacking-minigame/src/network/NetworkNodePathVisualizer.cs
@@ -1,0 +1,73 @@
+using Godot;
+using System.Collections.Generic;
+
+namespace network;
+
+public partial class NetworkNodePathVisualizer : Node2D
+{
+    [Export] Color PathNodeColor = Colors.Green;
+
+    [Export] Color PathEdgeColor = Colors.Green;
+    [Export] float PathEdgeLineWidt = 10f;
+
+    [Export] Color TrackedStartNodeColor = Colors.Green;
+
+    [Export] Color TrackedStartNodeEdgeColor = Colors.Green;
+    [Export] float TrackedStartNodeEdgeLineWidt = 10f;
+
+    public Network Network;
+    public List<NetworkNode> MarkedNodes = new();
+    public List<Edge> MarkedEdges = new();
+
+    public Node2D TrackedStartNode = null;
+
+    public override void _Process(double delta)
+    {
+        if (TrackedStartNode is not null)
+        {
+            QueueRedraw();
+        }
+    }
+
+    public override void _Draw()
+    {
+        if (TrackedStartNode is not null && MarkedNodes.Count > 0)
+        {
+            DrawCircle(ToLocal(TrackedStartNode.GlobalPosition), radius: 64, TrackedStartNodeColor);
+            DrawLine(ToLocal(TrackedStartNode.GlobalPosition), MarkedNodes[0].Position, TrackedStartNodeEdgeColor, TrackedStartNodeEdgeLineWidt);
+        }
+
+        foreach (var markedNode in MarkedNodes)
+        {
+            DrawCircle(markedNode.Position, radius: 64, PathNodeColor);
+        }
+
+        foreach (var markedEdge in MarkedEdges)
+        {
+            DrawLine(markedEdge.From.Position, markedEdge.To.Position, PathEdgeColor, PathEdgeLineWidt);
+        }
+    }
+
+    public void VisializePath(Network network, IEnumerable<NetworkNode> pathNodes, IEnumerable<Edge> pathEdges, Node2D trackedStartNode = null)
+    {
+        MarkedNodes = new(pathNodes);
+        MarkedEdges = new(pathEdges);
+
+        TrackedStartNode = trackedStartNode;
+
+        this.Visible = true;
+        QueueRedraw();
+    }
+
+    public void ShowVisualizedPath()
+    {
+        this.Visible = true;
+    }
+
+    public void HideVisualizedPath()
+    {
+        MarkedNodes.Clear();
+        MarkedEdges.Clear();
+        this.Visible = false;
+    }
+}

--- a/projects/hacking-minigame/src/network/network_node.tscn
+++ b/projects/hacking-minigame/src/network/network_node.tscn
@@ -1,10 +1,19 @@
-[gd_scene load_steps=3 format=3 uid="uid://cbnnj6rc7ldlx"]
+[gd_scene load_steps=4 format=3 uid="uid://cbnnj6rc7ldlx"]
 
 [ext_resource type="Script" path="res://src/network/NetworkNode.cs" id="1_y5p87"]
 [ext_resource type="Texture2D" uid="uid://bgc4jhbhn3l5x" path="res://icon.svg" id="2_55mpv"]
 
-[node name="NetworkNode" type="Node2D"]
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_myyaa"]
+size = Vector2(90, 90)
+
+[node name="NetworkNode" type="Node2D" node_paths=PackedStringArray("ClickableArea")]
 script = ExtResource("1_y5p87")
+ClickableArea = NodePath("ClickableArea")
+
+[node name="ClickableArea" type="Area2D" parent="."]
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="ClickableArea"]
+shape = SubResource("RectangleShape2D_myyaa")
 
 [node name="Sprite2D" type="Sprite2D" parent="."]
 scale = Vector2(0.7, 0.7)

--- a/projects/hacking-minigame/src/network/network_node.tscn
+++ b/projects/hacking-minigame/src/network/network_node.tscn
@@ -6,9 +6,8 @@
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_myyaa"]
 size = Vector2(90, 90)
 
-[node name="NetworkNode" type="Node2D" node_paths=PackedStringArray("ClickableArea")]
+[node name="NetworkNode" type="Node2D"]
 script = ExtResource("1_y5p87")
-ClickableArea = NodePath("ClickableArea")
 
 [node name="ClickableArea" type="Area2D" parent="."]
 

--- a/projects/hacking-minigame/src/player/Player.cs
+++ b/projects/hacking-minigame/src/player/Player.cs
@@ -1,8 +1,6 @@
 using Godot;
 using Godot.Collections;
 using network;
-using shared;
-using static Godot.GD;
 
 namespace player;
 
@@ -12,13 +10,5 @@ public partial class Player : Node2D
     [Export] public NetworkNode networkNode;
     [Export] Array<NetworkNode> nodePath;
 
-    public override async void _Ready()
-    {
-        foreach (var node in nodePath)
-        {
-            // TODO make movementSpeed configurable
-            await this.MoveToNode(node, movementSpeed: 200).GetFinishedAwaiter();
-            networkNode = node;
-        }
-    }
+    [Export] public int MovementSpeed = 200;
 }

--- a/projects/hacking-minigame/src/player/Player.cs
+++ b/projects/hacking-minigame/src/player/Player.cs
@@ -10,18 +10,15 @@ public partial class Player : Node2D
 {
     [Export] public Network network;
     [Export] public NetworkNode networkNode;
-    [Export] Array<Node2D> nodePath;
+    [Export] Array<NetworkNode> nodePath;
 
     public override async void _Ready()
     {
-        var movementAnimation = CreateTween();
-
         foreach (var node in nodePath)
         {
             // TODO make movementSpeed configurable
-            this.MoveToNode(node, movementSpeed: 200, existingTween: movementAnimation);
+            await this.MoveToNode(node, movementSpeed: 200).GetFinishedAwaiter();
+            networkNode = node;
         }
-
-        await movementAnimation.GetFinishedAwaiter();
     }
 }

--- a/projects/hacking-minigame/src/player/Player.cs
+++ b/projects/hacking-minigame/src/player/Player.cs
@@ -8,7 +8,6 @@ public partial class Player : Node2D
 {
     [Export] public Network network;
     [Export] public NetworkNode networkNode;
-    [Export] Array<NetworkNode> nodePath;
 
     [Export] public int MovementSpeed = 200;
 }

--- a/projects/hacking-minigame/src/player/Player.cs
+++ b/projects/hacking-minigame/src/player/Player.cs
@@ -10,15 +10,18 @@ public partial class Player : Node2D
 {
     [Export] public Network network;
     [Export] public NetworkNode networkNode;
-
     [Export] Array<Node2D> nodePath;
 
     public override async void _Ready()
     {
-        foreach (var node in this.nodePath)
+        var movementAnimation = CreateTween();
+
+        foreach (var node in nodePath)
         {
             // TODO make movementSpeed configurable
-            await this.MoveToNode(node, movementSpeed: 200).GetFinishedAwaiter();
+            this.MoveToNode(node, movementSpeed: 200, existingTween: movementAnimation);
         }
+
+        await movementAnimation.GetFinishedAwaiter();
     }
 }

--- a/projects/hacking-minigame/src/player/Player.cs
+++ b/projects/hacking-minigame/src/player/Player.cs
@@ -1,0 +1,24 @@
+using Godot;
+using Godot.Collections;
+using network;
+using shared;
+using static Godot.GD;
+
+namespace player;
+
+public partial class Player : Node2D
+{
+    [Export] public Network network;
+    [Export] public NetworkNode networkNode;
+
+    [Export] Array<Node2D> nodePath;
+
+    public override async void _Ready()
+    {
+        foreach (var node in this.nodePath)
+        {
+            // TODO make movementSpeed configurable
+            await this.MoveToNode(node, movementSpeed: 200).GetFinishedAwaiter();
+        }
+    }
+}

--- a/projects/hacking-minigame/src/player/Player.cs
+++ b/projects/hacking-minigame/src/player/Player.cs
@@ -1,5 +1,4 @@
 using Godot;
-using Godot.Collections;
 using network;
 
 namespace player;

--- a/projects/hacking-minigame/src/player/Player.cs
+++ b/projects/hacking-minigame/src/player/Player.cs
@@ -5,8 +5,8 @@ namespace player;
 
 public partial class Player : Node2D
 {
-    [Export] public Network network;
-    [Export] public NetworkNode networkNode;
+    [Export] public Network Network;
+    [Export] public NetworkNode NetworkNode;
 
     [Export] public int MovementSpeed = 200;
 }

--- a/projects/hacking-minigame/src/player/PlayerMovementController.cs
+++ b/projects/hacking-minigame/src/player/PlayerMovementController.cs
@@ -21,7 +21,7 @@ public partial class PlayerMovementController : Node2D
         Network.NetworkNodeMouseExit += OnNetworkNodeMouseExit;
 
         // Move player to initial node
-        PlayerMovementPath.Enqueue(Player.networkNode);
+        PlayerMovementPath.Enqueue(Player.NetworkNode);
     }
 
     public override void _Process(double delta)
@@ -42,7 +42,7 @@ public partial class PlayerMovementController : Node2D
                 var nextPlayerWaypoint = PlayerMovementPath.Dequeue();
 
                 // NOTE: update position before moving
-                Player.networkNode = nextPlayerWaypoint;
+                Player.NetworkNode = nextPlayerWaypoint;
 
                 var newMovementAnimation = CreateTween();
 
@@ -52,7 +52,7 @@ public partial class PlayerMovementController : Node2D
 
                 if (PathPreviewTarget is not null)
                 {
-                    var (pathNodes, pathEdges) = Network.GetNavigationPath(start: Player.networkNode, end: PathPreviewTarget);
+                    var (pathNodes, pathEdges) = Network.GetNavigationPath(start: Player.NetworkNode, end: PathPreviewTarget);
 
                     Network.PlayerNavigationPreviewVisualizer.VisializePath(Network, pathNodes, pathEdges, trackedStartNode: Player);
                 }
@@ -62,7 +62,7 @@ public partial class PlayerMovementController : Node2D
 
     private void OnNetworkNodeClicked(NetworkNode node, Network network)
     {
-        var (pathNodes, _) = network.GetNavigationPath(start: Player.networkNode, end: node);
+        var (pathNodes, _) = network.GetNavigationPath(start: Player.NetworkNode, end: node);
 
         PlayerMovementPath = new(pathNodes);
 
@@ -73,7 +73,7 @@ public partial class PlayerMovementController : Node2D
     {
         PathPreviewTarget = node;
 
-        var (pathNodes, pathEdges) = Network.GetNavigationPath(start: Player.networkNode, end: PathPreviewTarget);
+        var (pathNodes, pathEdges) = Network.GetNavigationPath(start: Player.NetworkNode, end: PathPreviewTarget);
 
         Network.PlayerNavigationPreviewVisualizer.VisializePath(Network, pathNodes, pathEdges, trackedStartNode: Player);
     }

--- a/projects/hacking-minigame/src/player/PlayerMovementController.cs
+++ b/projects/hacking-minigame/src/player/PlayerMovementController.cs
@@ -1,0 +1,83 @@
+using System.Collections.Generic;
+using Godot;
+using network;
+using shared;
+
+namespace player;
+
+public partial class PlayerMovementController : Node2D
+{
+    [Export] public Network Network;
+    [Export] public Player Player;
+
+    public NetworkNode PathPreviewTarget = null;
+    public Queue<NetworkNode> PlayerMovementPath = new();
+    public Tween PlayerMovementAnimation;
+
+    public override void _Ready()
+    {
+        Network.NetworkNodeClicked += OnNetworkNodeClicked;
+        Network.NetworkNodeMouseEnter += OnNetworkNodeMouseEnter;
+        Network.NetworkNodeMouseExit += OnNetworkNodeMouseExit;
+    }
+
+    public override void _Process(double delta)
+    {
+        if (PlayerMovementAnimation is null ||
+        (PlayerMovementAnimation is not null && !PlayerMovementAnimation.IsRunning()))
+        {
+            if (PlayerMovementPath.Count == 0)
+            {
+                // Nothing to do
+                Network.PlayerNavigationPathVisualizer.HideVisualizedPath();
+            }
+            else
+            {
+                // Queue up next animation
+                Network.PlayerNavigationPathVisualizer.VisializePath(Network, PlayerMovementPath, Network.GetEdgesOfNodePath(PlayerMovementPath), trackedStartNode: Player);
+
+                var nextPlayerWaypoint = PlayerMovementPath.Dequeue();
+
+                // NOTE: update position before moving
+                Player.networkNode = nextPlayerWaypoint;
+
+                var newMovementAnimation = CreateTween();
+
+                Player.MoveToNode(nextPlayerWaypoint, Player.MovementSpeed, existingTween: newMovementAnimation);
+
+                PlayerMovementAnimation = newMovementAnimation;
+
+                if (PathPreviewTarget is not null)
+                {
+                    var (pathNodes, pathEdges) = Network.GetNavigationPath(start: Player.networkNode, end: PathPreviewTarget);
+
+                    Network.PlayerNavigationPreviewVisualizer.VisializePath(Network, pathNodes, pathEdges, trackedStartNode: Player);
+                }
+            }
+        }
+    }
+
+    private void OnNetworkNodeClicked(NetworkNode node, Network network)
+    {
+        var (pathNodes, _) = network.GetNavigationPath(start: Player.networkNode, end: node);
+
+        PlayerMovementPath = new(pathNodes);
+
+        Network.PlayerNavigationPathVisualizer.VisializePath(Network, PlayerMovementPath, Network.GetEdgesOfNodePath(PlayerMovementPath), trackedStartNode: Player);
+    }
+
+    void OnNetworkNodeMouseEnter(NetworkNode node, Network network)
+    {
+        PathPreviewTarget = node;
+
+        var (pathNodes, pathEdges) = Network.GetNavigationPath(start: Player.networkNode, end: PathPreviewTarget);
+
+        Network.PlayerNavigationPreviewVisualizer.VisializePath(Network, pathNodes, pathEdges, trackedStartNode: Player);
+    }
+
+    void OnNetworkNodeMouseExit(NetworkNode _, Network network)
+    {
+        PathPreviewTarget = null;
+        network.PlayerNavigationPreviewVisualizer.HideVisualizedPath();
+    }
+}

--- a/projects/hacking-minigame/src/player/PlayerMovementController.cs
+++ b/projects/hacking-minigame/src/player/PlayerMovementController.cs
@@ -19,6 +19,9 @@ public partial class PlayerMovementController : Node2D
         Network.NetworkNodeClicked += OnNetworkNodeClicked;
         Network.NetworkNodeMouseEnter += OnNetworkNodeMouseEnter;
         Network.NetworkNodeMouseExit += OnNetworkNodeMouseExit;
+
+        // Move player to initial node
+        PlayerMovementPath.Enqueue(Player.networkNode);
     }
 
     public override void _Process(double delta)

--- a/projects/hacking-minigame/src/player/player.tscn
+++ b/projects/hacking-minigame/src/player/player.tscn
@@ -1,0 +1,14 @@
+[gd_scene load_steps=3 format=3 uid="uid://drkhn2puxovdv"]
+
+[ext_resource type="Script" path="res://src/player/Player.cs" id="1_0r2do"]
+[ext_resource type="Texture2D" uid="uid://bgc4jhbhn3l5x" path="res://icon.svg" id="2_unm08"]
+
+[node name="Player" type="Node2D" node_paths=PackedStringArray("nodePath")]
+script = ExtResource("1_0r2do")
+nodePath = []
+
+[node name="Sprite2D" type="Sprite2D" parent="."]
+modulate = Color(0.517647, 1, 0.219608, 1)
+scale = Vector2(0.5, 0.5)
+texture = ExtResource("2_unm08")
+metadata/_edit_lock_ = true

--- a/projects/hacking-minigame/src/shared/NodeExtensions.cs
+++ b/projects/hacking-minigame/src/shared/NodeExtensions.cs
@@ -27,13 +27,13 @@ public static class NodeExtensions
         return result;
     }
 
-    public static Tween MoveToNode(this Node2D node, Node2D target, int movementSpeed)
+    public static Tween MoveToNode(this Node2D node, Node2D target, int movementSpeed, Tween existingTween = null)
     {
         var distanceToNextNode = node.GlobalPosition.DistanceTo(target.GlobalPosition);
 
         var animationTime = distanceToNextNode / movementSpeed;
 
-        var movementAnimation = node.CreateTween();
+        var movementAnimation = existingTween ?? node.CreateTween();
 
         movementAnimation.TweenProperty(node, "global_position", target.GlobalPosition, animationTime);
 

--- a/projects/hacking-minigame/src/shared/NodeExtensions.cs
+++ b/projects/hacking-minigame/src/shared/NodeExtensions.cs
@@ -26,4 +26,17 @@ public static class NodeExtensions
 
         return result;
     }
+
+    public static Tween MoveToNode(this Node2D node, Node2D target, int movementSpeed)
+    {
+        var distanceToNextNode = node.GlobalPosition.DistanceTo(target.GlobalPosition);
+
+        var animationTime = distanceToNextNode / movementSpeed;
+
+        var movementAnimation = node.CreateTween();
+
+        movementAnimation.TweenProperty(node, "global_position", target.GlobalPosition, animationTime);
+
+        return movementAnimation;
+    }
 }

--- a/projects/hacking-minigame/src/shared/TweenExtensions.cs
+++ b/projects/hacking-minigame/src/shared/TweenExtensions.cs
@@ -1,0 +1,11 @@
+using Godot;
+
+namespace shared;
+
+public static class TweenExtensions
+{
+    public static SignalAwaiter GetFinishedAwaiter(this Tween tween)
+    {
+        return tween.ToSignal(tween, Tween.SignalName.Finished);
+    }
+}


### PR DESCRIPTION
- fixed tolerable build error which happened when redrawing `Edge`s in editor
- added forwarding of `NetworkNode` related mouse events through Network
- implemented Player navigation using godots `AStar2D`
  - navigation is initiated inside a new `PlayerMovementController`
  - for visualization and debugging I implemented `NetworkNodePathVisualizer`, which visualizes paths
    - currently: orange path is the path which the player is traveling and green path is a preview towards the node that the player is hovering over