### PR TITLE
Implement node overview UI cu 86bxg3fe7

### DIFF
--- a/projects/hacking-minigame/src/levels/sandbox.tscn
+++ b/projects/hacking-minigame/src/levels/sandbox.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=7 format=3 uid="uid://d3p67j68lg26b"]
+[gd_scene load_steps=8 format=3 uid="uid://d3p67j68lg26b"]
 
 [ext_resource type="Script" path="res://src/network/Network.cs" id="1_r1xda"]
 [ext_resource type="PackedScene" uid="uid://dsx77i0fiws4x" path="res://src/network/edge.tscn" id="2_ifm2w"]
@@ -6,76 +6,178 @@
 [ext_resource type="PackedScene" uid="uid://cbnnj6rc7ldlx" path="res://src/network/network_node.tscn" id="3_phs73"]
 [ext_resource type="PackedScene" uid="uid://drkhn2puxovdv" path="res://src/player/player.tscn" id="4_4pimd"]
 [ext_resource type="Script" path="res://src/player/PlayerMovementController.cs" id="5_hghsw"]
+[ext_resource type="Script" path="res://src/ui/ToggleCollapseButton.cs" id="7_cbbbk"]
 
-[node name="Sandbox" type="Node2D"]
+[node name="Root" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
 
-[node name="Network" type="Node2D" parent="."]
+[node name="Sandbox" type="Node2D" parent="."]
+
+[node name="Network" type="Node2D" parent="Sandbox"]
 position = Vector2(300, 150)
 script = ExtResource("1_r1xda")
 
-[node name="PlayerNavigationPreviewVisualizer" type="Node2D" parent="Network"]
+[node name="PlayerNavigationPreviewVisualizer" type="Node2D" parent="Sandbox/Network"]
 script = ExtResource("2_kbp3g")
 PathNodeColor = Color(0, 1, 0, 0)
 TrackedStartNodeColor = Color(0, 1, 0, 0)
 
-[node name="PlayerNavigationPathVisualizer" type="Node2D" parent="Network"]
+[node name="PlayerNavigationPathVisualizer" type="Node2D" parent="Sandbox/Network"]
 script = ExtResource("2_kbp3g")
 PathNodeColor = Color(0.858824, 0.278431, 0.262745, 0)
 PathEdgeColor = Color(0.72549, 0.392157, 0.160784, 1)
 TrackedStartNodeColor = Color(0.858824, 0.278431, 0.262745, 0)
 TrackedStartNodeEdgeColor = Color(0.72549, 0.392157, 0.160784, 1)
 
-[node name="Edges" type="Node2D" parent="Network"]
+[node name="Edges" type="Node2D" parent="Sandbox/Network"]
 
-[node name="0to1" parent="Network/Edges" node_paths=PackedStringArray("From", "To") instance=ExtResource("2_ifm2w")]
+[node name="0to1" parent="Sandbox/Network/Edges" node_paths=PackedStringArray("From", "To") instance=ExtResource("2_ifm2w")]
 From = NodePath("../../NetworkNodes/NetworkNode0")
 To = NodePath("../../NetworkNodes/NetworkNode1")
 
-[node name="0to2" parent="Network/Edges" node_paths=PackedStringArray("From", "To") instance=ExtResource("2_ifm2w")]
+[node name="0to2" parent="Sandbox/Network/Edges" node_paths=PackedStringArray("From", "To") instance=ExtResource("2_ifm2w")]
 From = NodePath("../../NetworkNodes/NetworkNode0")
 To = NodePath("../../NetworkNodes/NetworkNode2")
 
-[node name="1to2" parent="Network/Edges" node_paths=PackedStringArray("From", "To") instance=ExtResource("2_ifm2w")]
+[node name="1to2" parent="Sandbox/Network/Edges" node_paths=PackedStringArray("From", "To") instance=ExtResource("2_ifm2w")]
 From = NodePath("../../NetworkNodes/NetworkNode1")
 To = NodePath("../../NetworkNodes/NetworkNode2")
 
-[node name="2to3" parent="Network/Edges" node_paths=PackedStringArray("From", "To") instance=ExtResource("2_ifm2w")]
+[node name="2to3" parent="Sandbox/Network/Edges" node_paths=PackedStringArray("From", "To") instance=ExtResource("2_ifm2w")]
 From = NodePath("../../NetworkNodes/NetworkNode2")
 To = NodePath("../../NetworkNodes/NetworkNode3")
 
-[node name="3to4" parent="Network/Edges" node_paths=PackedStringArray("From", "To") instance=ExtResource("2_ifm2w")]
+[node name="3to4" parent="Sandbox/Network/Edges" node_paths=PackedStringArray("From", "To") instance=ExtResource("2_ifm2w")]
 From = NodePath("../../NetworkNodes/NetworkNode3")
 To = NodePath("../../NetworkNodes/NetworkNode4")
 
-[node name="4to5" parent="Network/Edges" node_paths=PackedStringArray("From", "To") instance=ExtResource("2_ifm2w")]
+[node name="4to5" parent="Sandbox/Network/Edges" node_paths=PackedStringArray("From", "To") instance=ExtResource("2_ifm2w")]
 From = NodePath("../../NetworkNodes/NetworkNode4")
 To = NodePath("../../NetworkNodes/NetworkNode5")
 
-[node name="NetworkNodes" type="Node2D" parent="Network"]
+[node name="NetworkNodes" type="Node2D" parent="Sandbox/Network"]
 
-[node name="NetworkNode0" parent="Network/NetworkNodes" instance=ExtResource("3_phs73")]
+[node name="NetworkNode0" parent="Sandbox/Network/NetworkNodes" instance=ExtResource("3_phs73")]
 
-[node name="NetworkNode1" parent="Network/NetworkNodes" instance=ExtResource("3_phs73")]
+[node name="NetworkNode1" parent="Sandbox/Network/NetworkNodes" instance=ExtResource("3_phs73")]
 position = Vector2(300, 0)
 
-[node name="NetworkNode2" parent="Network/NetworkNodes" instance=ExtResource("3_phs73")]
+[node name="NetworkNode2" parent="Sandbox/Network/NetworkNodes" instance=ExtResource("3_phs73")]
 position = Vector2(0, 300)
 
-[node name="NetworkNode3" parent="Network/NetworkNodes" instance=ExtResource("3_phs73")]
+[node name="NetworkNode3" parent="Sandbox/Network/NetworkNodes" instance=ExtResource("3_phs73")]
 position = Vector2(300, 300)
 
-[node name="NetworkNode4" parent="Network/NetworkNodes" instance=ExtResource("3_phs73")]
+[node name="NetworkNode4" parent="Sandbox/Network/NetworkNodes" instance=ExtResource("3_phs73")]
 position = Vector2(600, 300)
 
-[node name="NetworkNode5" parent="Network/NetworkNodes" instance=ExtResource("3_phs73")]
+[node name="NetworkNode5" parent="Sandbox/Network/NetworkNodes" instance=ExtResource("3_phs73")]
 position = Vector2(600, 0)
 
 [node name="Player" parent="." node_paths=PackedStringArray("Network", "NetworkNode") instance=ExtResource("4_4pimd")]
 position = Vector2(56, 79)
-Network = NodePath("../Network")
-NetworkNode = NodePath("../Network/NetworkNodes/NetworkNode0")
+Network = NodePath("../Sandbox/Network")
+NetworkNode = NodePath("../Sandbox/Network/NetworkNodes/NetworkNode0")
 
 [node name="PlayerMovementController" type="Node2D" parent="." node_paths=PackedStringArray("Network", "Player")]
 script = ExtResource("5_hghsw")
-Network = NodePath("../Network")
+Network = NodePath("../Sandbox/Network")
 Player = NodePath("../Player")
+
+[node name="NodeInformationSidebarContainer" type="HBoxContainer" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="NodeInformationSidebar" type="HBoxContainer" parent="NodeInformationSidebarContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_stretch_ratio = 30.0
+
+[node name="VBoxContainer" type="VBoxContainer" parent="NodeInformationSidebarContainer/NodeInformationSidebar"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_stretch_ratio = 90.0
+metadata/_edit_use_anchors_ = true
+
+[node name="NodeInformation" type="PanelContainer" parent="NodeInformationSidebarContainer/NodeInformationSidebar/VBoxContainer"]
+layout_mode = 2
+size_flags_vertical = 3
+size_flags_stretch_ratio = 20.0
+
+[node name="MarginContainer" type="MarginContainer" parent="NodeInformationSidebarContainer/NodeInformationSidebar/VBoxContainer/NodeInformation"]
+layout_mode = 2
+theme_override_constants/margin_left = 5
+theme_override_constants/margin_top = 5
+theme_override_constants/margin_right = 5
+theme_override_constants/margin_bottom = 5
+
+[node name="VBoxContainer" type="VBoxContainer" parent="NodeInformationSidebarContainer/NodeInformationSidebar/VBoxContainer/NodeInformation/MarginContainer"]
+layout_mode = 2
+
+[node name="NodeName" type="Label" parent="NodeInformationSidebarContainer/NodeInformationSidebar/VBoxContainer/NodeInformation/MarginContainer/VBoxContainer"]
+layout_mode = 2
+size_flags_vertical = 0
+text = "### NODE NAME ###"
+horizontal_alignment = 1
+
+[node name="RichTextLabel" type="RichTextLabel" parent="NodeInformationSidebarContainer/NodeInformationSidebar/VBoxContainer/NodeInformation/MarginContainer/VBoxContainer"]
+layout_mode = 2
+size_flags_vertical = 3
+text = "NODE ATTRIBUTES NODE ATTRIBUTES NODE ATTRIBUTES NODE ATTRIBUTES NODE ATTRIBUTES NODE ATTRIBUTES "
+
+[node name="NodeCommands" type="PanelContainer" parent="NodeInformationSidebarContainer/NodeInformationSidebar/VBoxContainer"]
+layout_mode = 2
+size_flags_vertical = 3
+size_flags_stretch_ratio = 80.0
+
+[node name="MarginContainer" type="MarginContainer" parent="NodeInformationSidebarContainer/NodeInformationSidebar/VBoxContainer/NodeCommands"]
+layout_mode = 2
+theme_override_constants/margin_left = 5
+theme_override_constants/margin_top = 5
+theme_override_constants/margin_right = 5
+theme_override_constants/margin_bottom = 5
+
+[node name="VBoxContainer" type="VBoxContainer" parent="NodeInformationSidebarContainer/NodeInformationSidebar/VBoxContainer/NodeCommands/MarginContainer"]
+layout_mode = 2
+
+[node name="InstallBREAK" type="Button" parent="NodeInformationSidebarContainer/NodeInformationSidebar/VBoxContainer/NodeCommands/MarginContainer/VBoxContainer"]
+layout_mode = 2
+text = "Install BREAK"
+
+[node name="InstallCOLLECT" type="Button" parent="NodeInformationSidebarContainer/NodeInformationSidebar/VBoxContainer/NodeCommands/MarginContainer/VBoxContainer"]
+layout_mode = 2
+text = "Install COLLECT"
+
+[node name="Disconnect" type="Button" parent="NodeInformationSidebarContainer/NodeInformationSidebar/VBoxContainer/NodeCommands/MarginContainer/VBoxContainer"]
+layout_mode = 2
+disabled = true
+text = "Disconnect
+"
+
+[node name="PanelContainer" type="PanelContainer" parent="NodeInformationSidebarContainer/NodeInformationSidebar"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_stretch_ratio = 10.0
+
+[node name="ToggleSideBarButton" type="Button" parent="NodeInformationSidebarContainer/NodeInformationSidebar/PanelContainer" node_paths=PackedStringArray("Target")]
+layout_mode = 2
+toggle_mode = true
+text = "<"
+script = ExtResource("7_cbbbk")
+TextUncollapsed = "<"
+TextCollapsed = ">"
+Target = NodePath("../../VBoxContainer")
+
+[node name="Padding" type="Control" parent="NodeInformationSidebarContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_stretch_ratio = 70.0

--- a/projects/hacking-minigame/src/levels/sandbox.tscn
+++ b/projects/hacking-minigame/src/levels/sandbox.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=8 format=3 uid="uid://d3p67j68lg26b"]
+[gd_scene load_steps=9 format=3 uid="uid://d3p67j68lg26b"]
 
 [ext_resource type="Script" path="res://src/network/Network.cs" id="1_r1xda"]
 [ext_resource type="PackedScene" uid="uid://dsx77i0fiws4x" path="res://src/network/edge.tscn" id="2_ifm2w"]
@@ -6,6 +6,7 @@
 [ext_resource type="PackedScene" uid="uid://cbnnj6rc7ldlx" path="res://src/network/network_node.tscn" id="3_phs73"]
 [ext_resource type="PackedScene" uid="uid://drkhn2puxovdv" path="res://src/player/player.tscn" id="4_4pimd"]
 [ext_resource type="Script" path="res://src/player/PlayerMovementController.cs" id="5_hghsw"]
+[ext_resource type="Script" path="res://src/ui/NodeInformationSidebar.cs" id="7_1uhm6"]
 [ext_resource type="Script" path="res://src/ui/ToggleCollapseButton.cs" id="7_cbbbk"]
 
 [node name="Root" type="Control"]
@@ -101,13 +102,17 @@ script = ExtResource("5_hghsw")
 Network = NodePath("../Level/Sandbox/Network")
 Player = NodePath("../Player")
 
-[node name="NodeInformationSidebarContainer" type="HBoxContainer" parent="LevelUi"]
+[node name="NodeInformationSidebarContainer" type="HBoxContainer" parent="LevelUi" node_paths=PackedStringArray("Player", "CurrentNodeName", "SidebarToggle")]
 layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
+script = ExtResource("7_1uhm6")
+Player = NodePath("../Player")
+CurrentNodeName = NodePath("NodeInformationSidebar/VBoxContainer/NodeInformation/MarginContainer/VBoxContainer/NodeName")
+SidebarToggle = NodePath("NodeInformationSidebar/PanelContainer/ToggleSideBarButton")
 
 [node name="NodeInformationSidebar" type="HBoxContainer" parent="LevelUi/NodeInformationSidebarContainer"]
 layout_mode = 2
@@ -186,6 +191,7 @@ layout_mode = 2
 toggle_mode = true
 button_pressed = true
 text = ">"
+text_overrun_behavior = 2
 script = ExtResource("7_cbbbk")
 TextUncollapsed = "<"
 TextCollapsed = ">"

--- a/projects/hacking-minigame/src/levels/sandbox.tscn
+++ b/projects/hacking-minigame/src/levels/sandbox.tscn
@@ -15,81 +15,93 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
+mouse_filter = 2
 
-[node name="Sandbox" type="Node2D" parent="."]
+[node name="LevelUi" type="Control" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+mouse_filter = 2
 
-[node name="Network" type="Node2D" parent="Sandbox"]
+[node name="Level" type="Node2D" parent="LevelUi"]
+
+[node name="Sandbox" type="Node2D" parent="LevelUi/Level"]
+
+[node name="Network" type="Node2D" parent="LevelUi/Level/Sandbox"]
 position = Vector2(300, 150)
 script = ExtResource("1_r1xda")
 
-[node name="PlayerNavigationPreviewVisualizer" type="Node2D" parent="Sandbox/Network"]
+[node name="PlayerNavigationPreviewVisualizer" type="Node2D" parent="LevelUi/Level/Sandbox/Network"]
 script = ExtResource("2_kbp3g")
 PathNodeColor = Color(0, 1, 0, 0)
 TrackedStartNodeColor = Color(0, 1, 0, 0)
 
-[node name="PlayerNavigationPathVisualizer" type="Node2D" parent="Sandbox/Network"]
+[node name="PlayerNavigationPathVisualizer" type="Node2D" parent="LevelUi/Level/Sandbox/Network"]
 script = ExtResource("2_kbp3g")
 PathNodeColor = Color(0.858824, 0.278431, 0.262745, 0)
 PathEdgeColor = Color(0.72549, 0.392157, 0.160784, 1)
 TrackedStartNodeColor = Color(0.858824, 0.278431, 0.262745, 0)
 TrackedStartNodeEdgeColor = Color(0.72549, 0.392157, 0.160784, 1)
 
-[node name="Edges" type="Node2D" parent="Sandbox/Network"]
+[node name="Edges" type="Node2D" parent="LevelUi/Level/Sandbox/Network"]
 
-[node name="0to1" parent="Sandbox/Network/Edges" node_paths=PackedStringArray("From", "To") instance=ExtResource("2_ifm2w")]
+[node name="0to1" parent="LevelUi/Level/Sandbox/Network/Edges" node_paths=PackedStringArray("From", "To") instance=ExtResource("2_ifm2w")]
 From = NodePath("../../NetworkNodes/NetworkNode0")
 To = NodePath("../../NetworkNodes/NetworkNode1")
 
-[node name="0to2" parent="Sandbox/Network/Edges" node_paths=PackedStringArray("From", "To") instance=ExtResource("2_ifm2w")]
+[node name="0to2" parent="LevelUi/Level/Sandbox/Network/Edges" node_paths=PackedStringArray("From", "To") instance=ExtResource("2_ifm2w")]
 From = NodePath("../../NetworkNodes/NetworkNode0")
 To = NodePath("../../NetworkNodes/NetworkNode2")
 
-[node name="1to2" parent="Sandbox/Network/Edges" node_paths=PackedStringArray("From", "To") instance=ExtResource("2_ifm2w")]
+[node name="1to2" parent="LevelUi/Level/Sandbox/Network/Edges" node_paths=PackedStringArray("From", "To") instance=ExtResource("2_ifm2w")]
 From = NodePath("../../NetworkNodes/NetworkNode1")
 To = NodePath("../../NetworkNodes/NetworkNode2")
 
-[node name="2to3" parent="Sandbox/Network/Edges" node_paths=PackedStringArray("From", "To") instance=ExtResource("2_ifm2w")]
+[node name="2to3" parent="LevelUi/Level/Sandbox/Network/Edges" node_paths=PackedStringArray("From", "To") instance=ExtResource("2_ifm2w")]
 From = NodePath("../../NetworkNodes/NetworkNode2")
 To = NodePath("../../NetworkNodes/NetworkNode3")
 
-[node name="3to4" parent="Sandbox/Network/Edges" node_paths=PackedStringArray("From", "To") instance=ExtResource("2_ifm2w")]
+[node name="3to4" parent="LevelUi/Level/Sandbox/Network/Edges" node_paths=PackedStringArray("From", "To") instance=ExtResource("2_ifm2w")]
 From = NodePath("../../NetworkNodes/NetworkNode3")
 To = NodePath("../../NetworkNodes/NetworkNode4")
 
-[node name="4to5" parent="Sandbox/Network/Edges" node_paths=PackedStringArray("From", "To") instance=ExtResource("2_ifm2w")]
+[node name="4to5" parent="LevelUi/Level/Sandbox/Network/Edges" node_paths=PackedStringArray("From", "To") instance=ExtResource("2_ifm2w")]
 From = NodePath("../../NetworkNodes/NetworkNode4")
 To = NodePath("../../NetworkNodes/NetworkNode5")
 
-[node name="NetworkNodes" type="Node2D" parent="Sandbox/Network"]
+[node name="NetworkNodes" type="Node2D" parent="LevelUi/Level/Sandbox/Network"]
 
-[node name="NetworkNode0" parent="Sandbox/Network/NetworkNodes" instance=ExtResource("3_phs73")]
+[node name="NetworkNode0" parent="LevelUi/Level/Sandbox/Network/NetworkNodes" instance=ExtResource("3_phs73")]
 
-[node name="NetworkNode1" parent="Sandbox/Network/NetworkNodes" instance=ExtResource("3_phs73")]
+[node name="NetworkNode1" parent="LevelUi/Level/Sandbox/Network/NetworkNodes" instance=ExtResource("3_phs73")]
 position = Vector2(300, 0)
 
-[node name="NetworkNode2" parent="Sandbox/Network/NetworkNodes" instance=ExtResource("3_phs73")]
+[node name="NetworkNode2" parent="LevelUi/Level/Sandbox/Network/NetworkNodes" instance=ExtResource("3_phs73")]
 position = Vector2(0, 300)
 
-[node name="NetworkNode3" parent="Sandbox/Network/NetworkNodes" instance=ExtResource("3_phs73")]
+[node name="NetworkNode3" parent="LevelUi/Level/Sandbox/Network/NetworkNodes" instance=ExtResource("3_phs73")]
 position = Vector2(300, 300)
 
-[node name="NetworkNode4" parent="Sandbox/Network/NetworkNodes" instance=ExtResource("3_phs73")]
+[node name="NetworkNode4" parent="LevelUi/Level/Sandbox/Network/NetworkNodes" instance=ExtResource("3_phs73")]
 position = Vector2(600, 300)
 
-[node name="NetworkNode5" parent="Sandbox/Network/NetworkNodes" instance=ExtResource("3_phs73")]
+[node name="NetworkNode5" parent="LevelUi/Level/Sandbox/Network/NetworkNodes" instance=ExtResource("3_phs73")]
 position = Vector2(600, 0)
 
-[node name="Player" parent="." node_paths=PackedStringArray("Network", "NetworkNode") instance=ExtResource("4_4pimd")]
+[node name="Player" parent="LevelUi" node_paths=PackedStringArray("Network", "TargetMovementPosition") instance=ExtResource("4_4pimd")]
 position = Vector2(56, 79)
-Network = NodePath("../Sandbox/Network")
-NetworkNode = NodePath("../Sandbox/Network/NetworkNodes/NetworkNode0")
+Network = NodePath("../Level/Sandbox/Network")
+TargetMovementPosition = NodePath("../Level/Sandbox/Network/NetworkNodes/NetworkNode0")
 
-[node name="PlayerMovementController" type="Node2D" parent="." node_paths=PackedStringArray("Network", "Player")]
+[node name="PlayerMovementController" type="Node2D" parent="LevelUi" node_paths=PackedStringArray("Network", "Player")]
 script = ExtResource("5_hghsw")
-Network = NodePath("../Sandbox/Network")
+Network = NodePath("../Level/Sandbox/Network")
 Player = NodePath("../Player")
 
-[node name="NodeInformationSidebarContainer" type="HBoxContainer" parent="."]
+[node name="NodeInformationSidebarContainer" type="HBoxContainer" parent="LevelUi"]
 layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
@@ -97,87 +109,90 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 
-[node name="NodeInformationSidebar" type="HBoxContainer" parent="NodeInformationSidebarContainer"]
+[node name="NodeInformationSidebar" type="HBoxContainer" parent="LevelUi/NodeInformationSidebarContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
-size_flags_stretch_ratio = 30.0
+size_flags_stretch_ratio = 3.0
 
-[node name="VBoxContainer" type="VBoxContainer" parent="NodeInformationSidebarContainer/NodeInformationSidebar"]
+[node name="VBoxContainer" type="VBoxContainer" parent="LevelUi/NodeInformationSidebarContainer/NodeInformationSidebar"]
+visible = false
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_stretch_ratio = 90.0
 metadata/_edit_use_anchors_ = true
 
-[node name="NodeInformation" type="PanelContainer" parent="NodeInformationSidebarContainer/NodeInformationSidebar/VBoxContainer"]
+[node name="NodeInformation" type="PanelContainer" parent="LevelUi/NodeInformationSidebarContainer/NodeInformationSidebar/VBoxContainer"]
 layout_mode = 2
 size_flags_vertical = 3
 size_flags_stretch_ratio = 20.0
 
-[node name="MarginContainer" type="MarginContainer" parent="NodeInformationSidebarContainer/NodeInformationSidebar/VBoxContainer/NodeInformation"]
+[node name="MarginContainer" type="MarginContainer" parent="LevelUi/NodeInformationSidebarContainer/NodeInformationSidebar/VBoxContainer/NodeInformation"]
 layout_mode = 2
 theme_override_constants/margin_left = 5
 theme_override_constants/margin_top = 5
 theme_override_constants/margin_right = 5
 theme_override_constants/margin_bottom = 5
 
-[node name="VBoxContainer" type="VBoxContainer" parent="NodeInformationSidebarContainer/NodeInformationSidebar/VBoxContainer/NodeInformation/MarginContainer"]
+[node name="VBoxContainer" type="VBoxContainer" parent="LevelUi/NodeInformationSidebarContainer/NodeInformationSidebar/VBoxContainer/NodeInformation/MarginContainer"]
 layout_mode = 2
 
-[node name="NodeName" type="Label" parent="NodeInformationSidebarContainer/NodeInformationSidebar/VBoxContainer/NodeInformation/MarginContainer/VBoxContainer"]
+[node name="NodeName" type="Label" parent="LevelUi/NodeInformationSidebarContainer/NodeInformationSidebar/VBoxContainer/NodeInformation/MarginContainer/VBoxContainer"]
 layout_mode = 2
 size_flags_vertical = 0
 text = "### NODE NAME ###"
 horizontal_alignment = 1
 
-[node name="RichTextLabel" type="RichTextLabel" parent="NodeInformationSidebarContainer/NodeInformationSidebar/VBoxContainer/NodeInformation/MarginContainer/VBoxContainer"]
+[node name="RichTextLabel" type="RichTextLabel" parent="LevelUi/NodeInformationSidebarContainer/NodeInformationSidebar/VBoxContainer/NodeInformation/MarginContainer/VBoxContainer"]
 layout_mode = 2
 size_flags_vertical = 3
 text = "NODE ATTRIBUTES NODE ATTRIBUTES NODE ATTRIBUTES NODE ATTRIBUTES NODE ATTRIBUTES NODE ATTRIBUTES "
 
-[node name="NodeCommands" type="PanelContainer" parent="NodeInformationSidebarContainer/NodeInformationSidebar/VBoxContainer"]
+[node name="NodeCommands" type="PanelContainer" parent="LevelUi/NodeInformationSidebarContainer/NodeInformationSidebar/VBoxContainer"]
 layout_mode = 2
 size_flags_vertical = 3
 size_flags_stretch_ratio = 80.0
 
-[node name="MarginContainer" type="MarginContainer" parent="NodeInformationSidebarContainer/NodeInformationSidebar/VBoxContainer/NodeCommands"]
+[node name="MarginContainer" type="MarginContainer" parent="LevelUi/NodeInformationSidebarContainer/NodeInformationSidebar/VBoxContainer/NodeCommands"]
 layout_mode = 2
 theme_override_constants/margin_left = 5
 theme_override_constants/margin_top = 5
 theme_override_constants/margin_right = 5
 theme_override_constants/margin_bottom = 5
 
-[node name="VBoxContainer" type="VBoxContainer" parent="NodeInformationSidebarContainer/NodeInformationSidebar/VBoxContainer/NodeCommands/MarginContainer"]
+[node name="VBoxContainer" type="VBoxContainer" parent="LevelUi/NodeInformationSidebarContainer/NodeInformationSidebar/VBoxContainer/NodeCommands/MarginContainer"]
 layout_mode = 2
 
-[node name="InstallBREAK" type="Button" parent="NodeInformationSidebarContainer/NodeInformationSidebar/VBoxContainer/NodeCommands/MarginContainer/VBoxContainer"]
+[node name="InstallBREAK" type="Button" parent="LevelUi/NodeInformationSidebarContainer/NodeInformationSidebar/VBoxContainer/NodeCommands/MarginContainer/VBoxContainer"]
 layout_mode = 2
 text = "Install BREAK"
 
-[node name="InstallCOLLECT" type="Button" parent="NodeInformationSidebarContainer/NodeInformationSidebar/VBoxContainer/NodeCommands/MarginContainer/VBoxContainer"]
+[node name="InstallCOLLECT" type="Button" parent="LevelUi/NodeInformationSidebarContainer/NodeInformationSidebar/VBoxContainer/NodeCommands/MarginContainer/VBoxContainer"]
 layout_mode = 2
 text = "Install COLLECT"
 
-[node name="Disconnect" type="Button" parent="NodeInformationSidebarContainer/NodeInformationSidebar/VBoxContainer/NodeCommands/MarginContainer/VBoxContainer"]
+[node name="Disconnect" type="Button" parent="LevelUi/NodeInformationSidebarContainer/NodeInformationSidebar/VBoxContainer/NodeCommands/MarginContainer/VBoxContainer"]
 layout_mode = 2
 disabled = true
 text = "Disconnect
 "
 
-[node name="PanelContainer" type="PanelContainer" parent="NodeInformationSidebarContainer/NodeInformationSidebar"]
+[node name="PanelContainer" type="PanelContainer" parent="LevelUi/NodeInformationSidebarContainer/NodeInformationSidebar"]
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_stretch_ratio = 10.0
 
-[node name="ToggleSideBarButton" type="Button" parent="NodeInformationSidebarContainer/NodeInformationSidebar/PanelContainer" node_paths=PackedStringArray("Target")]
+[node name="ToggleSideBarButton" type="Button" parent="LevelUi/NodeInformationSidebarContainer/NodeInformationSidebar/PanelContainer" node_paths=PackedStringArray("Target")]
 layout_mode = 2
 toggle_mode = true
-text = "<"
+button_pressed = true
+text = ">"
 script = ExtResource("7_cbbbk")
 TextUncollapsed = "<"
 TextCollapsed = ">"
 Target = NodePath("../../VBoxContainer")
 
-[node name="Padding" type="Control" parent="NodeInformationSidebarContainer"]
+[node name="Padding" type="Control" parent="LevelUi/NodeInformationSidebarContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
-size_flags_stretch_ratio = 70.0
+size_flags_stretch_ratio = 97.0
+mouse_filter = 2

--- a/projects/hacking-minigame/src/network/NetworkNodePathVisualizer.cs
+++ b/projects/hacking-minigame/src/network/NetworkNodePathVisualizer.cs
@@ -48,7 +48,7 @@ public partial class NetworkNodePathVisualizer : Node2D
         }
     }
 
-    public void VisializePath(Network network, IEnumerable<NetworkNode> pathNodes, IEnumerable<Edge> pathEdges, Node2D trackedStartNode = null)
+    public void VisualizePath(Network network, IEnumerable<NetworkNode> pathNodes, IEnumerable<Edge> pathEdges, Node2D trackedStartNode = null)
     {
         MarkedNodes = new(pathNodes);
         MarkedEdges = new(pathEdges);

--- a/projects/hacking-minigame/src/player/Player.cs
+++ b/projects/hacking-minigame/src/player/Player.cs
@@ -5,8 +5,25 @@ namespace player;
 
 public partial class Player : Node2D
 {
+    [Signal] public delegate void ArrivedAtNodeEventHandler(NetworkNode node, Player player);
+
     [Export] public Network Network;
-    [Export] public NetworkNode NetworkNode;
 
     [Export] public int MovementSpeed = 200;
+
+    [Export] public NetworkNode TargetMovementPosition;
+
+    public NetworkNode CurrentPosition
+    {
+        get => _currentPosition;
+        set
+        {
+            _currentPosition = value;
+            if (_currentPosition is not null)
+            {
+                EmitSignal(nameof(ArrivedAtNode), _currentPosition, this);
+            }
+        }
+    }
+    private NetworkNode _currentPosition;
 }

--- a/projects/hacking-minigame/src/player/PlayerMovementController.cs
+++ b/projects/hacking-minigame/src/player/PlayerMovementController.cs
@@ -37,7 +37,7 @@ public partial class PlayerMovementController : Node2D
             else
             {
                 // Queue up next animation
-                Network.PlayerNavigationPathVisualizer.VisializePath(Network, PlayerMovementPath, Network.GetEdgesOfNodePath(PlayerMovementPath), trackedStartNode: Player);
+                Network.PlayerNavigationPathVisualizer.VisualizePath(Network, PlayerMovementPath, Network.GetEdgesOfNodePath(PlayerMovementPath), trackedStartNode: Player);
 
                 var nextPlayerWaypoint = PlayerMovementPath.Dequeue();
 
@@ -54,7 +54,7 @@ public partial class PlayerMovementController : Node2D
                 {
                     var (pathNodes, pathEdges) = Network.GetNavigationPath(start: Player.NetworkNode, end: PathPreviewTarget);
 
-                    Network.PlayerNavigationPreviewVisualizer.VisializePath(Network, pathNodes, pathEdges, trackedStartNode: Player);
+                    Network.PlayerNavigationPreviewVisualizer.VisualizePath(Network, pathNodes, pathEdges, trackedStartNode: Player);
                 }
             }
         }
@@ -66,7 +66,7 @@ public partial class PlayerMovementController : Node2D
 
         PlayerMovementPath = new(pathNodes);
 
-        Network.PlayerNavigationPathVisualizer.VisializePath(Network, PlayerMovementPath, Network.GetEdgesOfNodePath(PlayerMovementPath), trackedStartNode: Player);
+        Network.PlayerNavigationPathVisualizer.VisualizePath(Network, PlayerMovementPath, Network.GetEdgesOfNodePath(PlayerMovementPath), trackedStartNode: Player);
     }
 
     void OnNetworkNodeMouseEnter(NetworkNode node, Network network)
@@ -75,7 +75,7 @@ public partial class PlayerMovementController : Node2D
 
         var (pathNodes, pathEdges) = Network.GetNavigationPath(start: Player.NetworkNode, end: PathPreviewTarget);
 
-        Network.PlayerNavigationPreviewVisualizer.VisializePath(Network, pathNodes, pathEdges, trackedStartNode: Player);
+        Network.PlayerNavigationPreviewVisualizer.VisualizePath(Network, pathNodes, pathEdges, trackedStartNode: Player);
     }
 
     void OnNetworkNodeMouseExit(NetworkNode _, Network network)

--- a/projects/hacking-minigame/src/shared/ContainerExtensions.cs
+++ b/projects/hacking-minigame/src/shared/ContainerExtensions.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+using System.Linq;
+using Godot;
+
+namespace shared;
+
+public static class ControlExtensions
+{
+    public static void ResizeControlUsingContainerRatio(this Control control, float newRatio)
+    {
+        var ratioToCompensate = control.SizeFlagsStretchRatio - newRatio;
+
+        control.SizeFlagsStretchRatio = newRatio;
+
+        var containerSiblings = new List<Control>(control.GetParent().GetChildren<Control>())
+            .Where(s => s.GetInstanceId() != control.GetInstanceId()).ToList();
+
+        var ratioToCompensatePerSibling = ratioToCompensate / containerSiblings.Count;
+
+        foreach (var parentSibling in containerSiblings)
+        {
+            parentSibling.SizeFlagsStretchRatio += ratioToCompensatePerSibling;
+        }
+    }
+}

--- a/projects/hacking-minigame/src/ui/NodeInformationSidebar.cs
+++ b/projects/hacking-minigame/src/ui/NodeInformationSidebar.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Linq;
+using Godot;
+using network;
+using player;
+
+namespace ui;
+
+public partial class NodeInformationSidebar : Control
+{
+    [Export] public Player Player;
+    [Export] public Label CurrentNodeName;
+    [Export] public ToggleCollapseButton SidebarToggle;
+
+    public override void _Ready()
+    {
+        Player.ArrivedAtNode += OnPlayerArrivedAtNode;
+    }
+
+    private void OnPlayerArrivedAtNode(NetworkNode node, Player player)
+    {
+        CurrentNodeName.Text = node.Name;
+
+        // display node name vertically
+        string verticalString = string.Join('\n', node.Name.ToString().Select(c => c.ToString()));
+        SidebarToggle.TextCollapsed = $">\n{verticalString}\n>";
+    }
+}

--- a/projects/hacking-minigame/src/ui/ToggleCollapseButton.cs
+++ b/projects/hacking-minigame/src/ui/ToggleCollapseButton.cs
@@ -12,7 +12,7 @@ namespace ui;
 public partial class ToggleCollapseButton : Button
 {
     [Export]
-    string TextUncollapsed
+    public string TextUncollapsed
     {
         get => _textUncollapsed;
         set
@@ -23,7 +23,7 @@ public partial class ToggleCollapseButton : Button
     }
 
     [Export]
-    string TextCollapsed
+    public string TextCollapsed
     {
         get => _textCollapsed;
         set
@@ -37,7 +37,7 @@ public partial class ToggleCollapseButton : Button
     private string _textCollapsed;
 
     [Export]
-    Control Target
+    public Control Target
     {
         get => target;
         set
@@ -53,7 +53,7 @@ public partial class ToggleCollapseButton : Button
 
     private Control target;
 
-    Control TargetParent;
+    private Control TargetParent;
 
     public override void _Ready()
     {

--- a/projects/hacking-minigame/src/ui/ToggleCollapseButton.cs
+++ b/projects/hacking-minigame/src/ui/ToggleCollapseButton.cs
@@ -1,0 +1,152 @@
+using System.Collections.Generic;
+using System.Linq;
+using Godot;
+using shared;
+
+namespace ui;
+
+/// <summary>
+/// Collapses a <see cref="Target"/> <see cref="Control"/> according to the current <see cref="BaseButton.ButtonPressed"/> value.
+/// </summary>
+[Tool]
+public partial class ToggleCollapseButton : Button
+{
+    [Export]
+    string TextUncollapsed
+    {
+        get => _textUncollapsed;
+        set
+        {
+            _textUncollapsed = value;
+            ChangeButtonText(ButtonPressed);
+        }
+    }
+
+    [Export]
+    string TextCollapsed
+    {
+        get => _textCollapsed;
+        set
+        {
+            _textCollapsed = value;
+            ChangeButtonText(ButtonPressed);
+        }
+    }
+
+    private string _textUncollapsed;
+    private string _textCollapsed;
+
+    [Export]
+    Control Target
+    {
+        get => target;
+        set
+        {
+            target = value;
+
+            if (Target is not null)
+            {
+                TargetParent = Target.GetParent<Control>();
+            }
+        }
+    }
+
+    private Control target;
+
+    Control TargetParent;
+
+    public override void _Ready()
+    {
+        Toggled += OnButtonToggle;
+    }
+
+    private void OnButtonToggle(bool toggledOn)
+    {
+        Refresh(toggledOn);
+    }
+
+    private void Refresh(bool shouldCollapse)
+    {
+        ChangeButtonText(shouldCollapse);
+        CollapseTarget(shouldCollapse);
+    }
+
+    private void ChangeButtonText(bool isCollapsed)
+    {
+        if (isCollapsed)
+        {
+            Text = TextCollapsed ?? Text;
+        }
+        else
+        {
+            Text = TextUncollapsed ?? Text;
+        }
+    }
+
+    private void CollapseTarget(bool isCollapsed)
+    {
+        if (Target is not null)
+        {
+            if (TargetParent is Container)
+            {
+                CollapseTargetUsingContainerRatio(isCollapsed);
+            }
+            else
+            {
+                CollapseTargetUsingSize(isCollapsed);
+            }
+        }
+    }
+
+    private void CollapseTargetUsingSize(bool isCollapsed)
+    {
+        var newParentWidth = TargetParent.Size.X;
+
+        if (isCollapsed)
+        {
+            newParentWidth -= Target.Size.X;
+
+            Target.Visible = false;
+        }
+        else
+        {
+            newParentWidth += Target.Size.X;
+
+            Target.Visible = true;
+        }
+
+        var oldParentHeight = TargetParent.Size.Y;
+
+        var newParentSize = new Vector2(newParentWidth, oldParentHeight);
+
+        TargetParent.SetSize(newParentSize);
+    }
+
+    private void CollapseTargetUsingContainerRatio(bool isCollapsed)
+    {
+        var parentChildren = new List<Control>(TargetParent.GetChildren<Control>());
+
+        var totalRatioOfParentChildren = parentChildren.Sum(c => c.SizeFlagsStretchRatio);
+
+        var oldParentRatio = TargetParent.SizeFlagsStretchRatio;
+
+        var newParentRatio = oldParentRatio;
+
+        if (isCollapsed)
+        {
+            var removedParentRatio = oldParentRatio * (Target.SizeFlagsStretchRatio / totalRatioOfParentChildren);
+
+            newParentRatio -= removedParentRatio;
+        }
+        else
+        {
+            var addedParentRatio = Target.SizeFlagsStretchRatio * oldParentRatio / (totalRatioOfParentChildren - Target.SizeFlagsStretchRatio);
+
+            newParentRatio += addedParentRatio;
+        }
+
+        TargetParent.ResizeControlUsingContainerRatio(newParentRatio);
+
+        Target.Visible = !isCollapsed;
+    }
+}


### PR DESCRIPTION
- `Player`:
  - renamed `Player.NetworkNode` to `Player.TargetMovementPosition` to avoid confusion
  - added `Player.CurrentPosition` which is set when a player reaches a node during navigation
  - when player reaches a node `Player.ArrivedAtNode` signal is also emitted

- implemented UI to display node information (see `NodeInformationSidebar`)
  - the ui is a collapsible sidebar which is controlled by a `ToggleCollapseButton`
    - I hope that this format will give us enough freedom to implement our feature set
    - but the ui may be simplified in the future
    
- restructured the scene tree to allow controls to assume full screen aspect ratio
  - together with godot containers this should make our ui responsive to game resolution changes

- corrected typo in `PlayerMovementController`